### PR TITLE
feat(api): Add GET /jobs endpoint to list recent job history

### DIFF
--- a/src/booty/jobs.py
+++ b/src/booty/jobs.py
@@ -185,3 +185,33 @@ class JobQueue:
             Job if found, None otherwise
         """
         return self.jobs.get(job_id)
+
+    def get_recent_jobs(self, limit: int = 100) -> list[dict]:
+        """Get recent jobs sorted by creation time (newest first).
+
+        Args:
+            limit: Maximum number of jobs to return
+
+        Returns:
+            List of job dictionaries with relevant fields
+        """
+        sorted_jobs = sorted(
+            self.jobs.values(),
+            key=lambda j: j.created_at,
+            reverse=True
+        )
+
+        recent_jobs = sorted_jobs[:limit]
+
+        return [
+            {
+                "job_id": job.job_id,
+                "issue_number": job.issue_number,
+                "issue_url": job.issue_url,
+                "state": job.state.value,
+                "created_at": job.created_at.isoformat(),
+                "error": job.error,
+                "is_self_modification": job.is_self_modification,
+            }
+            for job in recent_jobs
+        ]

--- a/src/booty/main.py
+++ b/src/booty/main.py
@@ -111,3 +111,17 @@ async def health_check():
         dict: Status OK
     """
     return {"status": "ok"}
+
+
+@app.get("/jobs")
+async def list_jobs():
+    """List recent job history.
+
+    Returns:
+        dict: JSON response with list of recent jobs including issue_number, status, and timestamp
+    """
+    if job_queue is None:
+        return {"jobs": [], "error": "Job queue not initialized"}
+
+    jobs = job_queue.get_recent_jobs(limit=100)
+    return {"jobs": jobs, "total": len(jobs)}


### PR DESCRIPTION
## Safety Summary

**File Changes:** 2 file(s) modified

**Changed Files:**
- src/booty/jobs.py
- src/booty/main.py

**Protected Paths Verified:**
- .github/workflows/**
- .env
- .env.*
- **/*.env
- **/secrets.*
- Dockerfile
- docker-compose*.yml

**Confirmation:** No protected paths were modified.

---

## Summary
To implement the GET /jobs endpoint, I need to: 1) Add a new endpoint in main.py that returns job history, 2) Add a method to JobQueue in jobs.py to retrieve recent jobs with their status, 3) The endpoint should return JSON with job information including issue_number, status (state), and timestamp (created_at), 4) Keep the implementation simple and follow existing patterns in the codebase. The approach is to add a get_recent_jobs() method to JobQueue that returns a list of jobs sorted by creation time, and add a GET /jobs endpoint in main.py that calls this method and formats the response.

## Changes
| File | Operation | Description |
|------|-----------|-------------|
| src/booty/jobs.py | modify | Added get_recent_jobs() method to JobQueue class that returns a list of recent jobs sorted by creation time (newest first). The method converts Job objects to dictionaries with relevant fields for JSON serialization, including job_id, issue_number, state, created_at timestamp, and error information. |
| src/booty/main.py | modify | Added GET /jobs endpoint that returns a JSON list of recent jobs. The endpoint calls job_queue.get_recent_jobs() to retrieve up to 100 recent jobs with their issue_number, state (status), created_at (timestamp), and other relevant information. This provides visibility into the pipeline without requiring log access. |

## Testing
To test the changes:

1. Start the application and ensure it initializes correctly
2. Send a webhook to create some jobs (or wait for jobs to be created naturally)
3. Make a GET request to /jobs endpoint: curl http://localhost:8000/jobs
4. Verify the response contains a JSON object with:
   - A 'jobs' array containing job objects
   - Each job object should have: job_id, issue_number, issue_url, state, created_at, error (if any), is_self_modification
   - A 'total' field indicating the number of jobs returned
5. Verify jobs are sorted by created_at in descending order (newest first)
6. Test with no jobs in the queue to ensure it returns an empty array
7. Test with more than 100 jobs to ensure the limit works correctly

---
Fixes #1
Generated by Booty (self-modification)