### PR TITLE
feat: attribute Builder commits to Booty Agent

### DIFF
--- a/src/booty/code_gen/generator.py
+++ b/src/booty/code_gen/generator.py
@@ -13,6 +13,7 @@ from booty.code_gen.security import PathRestrictor
 from booty.code_gen.validator import validate_generated_code
 from booty.test_generation import detect_conventions, validate_test_imports
 from booty.config import Settings
+from git import Actor
 from booty.git.operations import commit_changes, format_commit_message, push_to_remote
 from booty.github.pulls import (
     add_agent_builder_label,
@@ -435,11 +436,17 @@ async def process_issue_to_pr(
                 plan.approach,
                 job.issue_number,
             )
+        actor = Actor(
+            settings.BOOTY_GIT_AUTHOR_NAME,
+            settings.BOOTY_GIT_AUTHOR_EMAIL,
+        )
         commit_sha = commit_changes(
             workspace.repo,
             modified_paths,
             commit_message,
             deleted_paths if deleted_paths else None,
+            author=actor,
+            committer=actor,
         )
         logger.info("changes_committed", sha=commit_sha)
 

--- a/src/booty/config.py
+++ b/src/booty/config.py
@@ -33,6 +33,10 @@ class Settings(BaseSettings):
     MAX_FILES_PER_ISSUE: int = 10  # File count cap
     RESTRICTED_PATHS: str = ".github/workflows/**,.env,.env.*,**/*.env,**/secrets.*,Dockerfile,docker-compose*.yml,*lock.json,*.lock,.booty.yml"  # Comma-separated denylist patterns
 
+    # Git commit attribution (Builder agent commits)
+    BOOTY_GIT_AUTHOR_NAME: str = "Booty Agent"
+    BOOTY_GIT_AUTHOR_EMAIL: str = "noreply@booty.dev"
+
     # Self-modification configuration
     BOOTY_OWN_REPO_URL: str = ""  # Empty means self-modification detection disabled
     BOOTY_SELF_MODIFY_ENABLED: bool = False  # Explicit opt-in required

--- a/src/booty/git/operations.py
+++ b/src/booty/git/operations.py
@@ -3,6 +3,7 @@
 import asyncio
 
 import git
+from git import Actor
 
 from booty.logging import get_logger
 
@@ -14,6 +15,9 @@ def commit_changes(
     file_paths: list[str],
     message: str,
     deleted_paths: list[str] | None = None,
+    *,
+    author: Actor | None = None,
+    committer: Actor | None = None,
 ) -> str:
     """Commit changes to repository.
 
@@ -22,10 +26,16 @@ def commit_changes(
         file_paths: List of file paths to add
         message: Commit message
         deleted_paths: Optional list of file paths to remove
+        author: Optional commit author (default: Booty Agent)
+        committer: Optional committer (default: same as author)
 
     Returns:
         Commit SHA
     """
+    actor = author or committer or Actor("Booty Agent", "noreply@booty.dev")
+    author = author or actor
+    committer = committer or actor
+
     # Stage files to add
     if file_paths:
         repo.index.add(file_paths)
@@ -37,7 +47,7 @@ def commit_changes(
         logger.info("files_removed", count=len(deleted_paths))
 
     # Commit changes
-    commit = repo.index.commit(message)
+    commit = repo.index.commit(message, author=author, committer=committer)
     commit_sha = str(commit)
 
     logger.info("changes_committed", sha=commit_sha)


### PR DESCRIPTION
Builder commits now show **Booty Agent** instead of the system user.

## Changes
- Add `BOOTY_GIT_AUTHOR_NAME`, `BOOTY_GIT_AUTHOR_EMAIL` to Settings
- `commit_changes` accepts `author`/`committer`; defaults to Booty Agent
- Generator passes Actor from settings to `commit_changes`

Override via env (e.g. `BOOTY_GIT_AUTHOR_EMAIL=bot@company.com`) for GitHub App identity.

Made with [Cursor](https://cursor.com)